### PR TITLE
Fix #19: Crash when switching back to invalid grammar

### DIFF
--- a/src/exampleWorkerManager.js
+++ b/src/exampleWorkerManager.js
@@ -51,18 +51,17 @@ ohmEditor.addListener('parse:grammar', function(_, g, err) {
 });
 
 ohmEditor.examples.addListener('set:example', function(_, oldValue, newValue) {
-  var grammar;
   if (newValue.text.trim() === '') {
     return;
-  } else if (oldValue && oldValue.text.trim() === '' ||
-             !oldValue) {
-    grammar = ohmEditor.grammar;
-    if (grammar.match(newValue.text, newValue.startRule).succeeded()) {
-      exampleWorkerManager.addUserExample(newValue.startRule || grammar.defaultStartRule,
-                                          newValue.text);
-    }
-  } else {
-    resetWorker(ohmEditor.grammar);
+  }
+
+  var g = ohmEditor.grammar;
+  if (oldValue && oldValue.text.trim() !== '') {
+    resetWorker(g);
+  } else if (g && g.match(newValue.text, newValue.startRule).succeeded()) {
+    exampleWorkerManager.addUserExample(
+        newValue.startRule || g.defaultStartRule,
+        newValue.text);
   }
 });
 


### PR DESCRIPTION
The simplest fix to prevent this crash is to just check that grammar is non-null before calling `match`, but it seemed like logic could be made a bit more clear in this function, so I cleaned that up as well.

@sakekasi, please take a look and let me know if (a) I got the logic right, and (b) if this is even the right place to fix it.