### PR TITLE
feat: Add support for multiple grammars in the same file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 2018,
     sourceType: 'script',
   },
   overrides: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,8 @@ module.exports = {
 
     'max-len': ['error', {code: 100, ignoreUrls: true}],
 
+    'no-console': 2,
+
     // Don't allow require() statements to include the '.js' extension.
     'no-extension-in-require/main': 2,
 

--- a/src/components/example-editor.vue
+++ b/src/components/example-editor.vue
@@ -109,7 +109,6 @@ export default {
     topLevelOption() {
       const {selectedGrammar, startRule} = this.example;
       const ruleLabel = startRule || `(default)`;
-      this.startRuleDropdownKey;
       return {
         text: selectedGrammar ? `${selectedGrammar} ▸ ${ruleLabel}` : ruleLabel,
         value: toOptValue(selectedGrammar, startRule),

--- a/src/components/example-editor.vue
+++ b/src/components/example-editor.vue
@@ -158,9 +158,12 @@ export default {
   },
   methods: {
     handleStartRuleDropdownChange(e) {
-      const newVal = e.target.value;
+      let {value} = e.target;
+
       // Strip off any trailing '!', which can be added to avoid value collisions.
-      const value = newVal.endsWith('!') ? newVal.slice(0, -1) : newVal;
+      if (value.endsWith('!')) {
+        value = value.slice(0, -1);
+      }
 
       const [grammarName, startRule] = value.split('.');
       this.$emit('setGrammarAndStartRule', grammarName, startRule);

--- a/src/components/example-editor.vue
+++ b/src/components/example-editor.vue
@@ -62,7 +62,8 @@
 import domUtil from '../domUtil';
 import ohmEditor from '../ohmEditor';
 
-const toOptValue = (grammarName, startRule) => `${grammarName || ''}.${startRule || ''}`;
+const toOptValue = (grammarName, startRule) =>
+  `${grammarName || ''}.${startRule || ''}`;
 
 export default {
   name: 'example-editor',
@@ -163,7 +164,6 @@ export default {
       const value = newVal.endsWith('!') ? newVal.slice(0, -1) : newVal;
 
       const [grammarName, startRule] = value.split('.');
-      console.log('setting', grammarName, startRule);
       this.$emit('setGrammarAndStartRule', grammarName, startRule);
 
       // Ensure the start rule dropdown is re-rendered. We need to force this for

--- a/src/components/example-list.css
+++ b/src/components/example-list.css
@@ -108,14 +108,15 @@ x:-moz-any-link {
 }
 
 .startRule {
-  color: hsl(0, 0%, 85%);
+  cursor: default;
+  color: hsl(0, 0%, 75%);
   font-family: inherit;
   font-size: 12px;
   margin-right: 4px;
 }
 
 .selected .startRule {
-  color: hsl(0, 0%, 75%);
+  color: hsl(0, 0%, 65%);
 }
 
 #startRuleDropdown {

--- a/src/components/example-list.css
+++ b/src/components/example-list.css
@@ -118,6 +118,10 @@ x:-moz-any-link {
   color: hsl(0, 0%, 75%);
 }
 
+#startRuleDropdown {
+  min-width: 85px;
+}
+
 #userExampleContainer > .contents {
   border-top: 1px solid #ddd;
   flex: 1;
@@ -183,6 +187,7 @@ x:-moz-any-link {
 
 #exampleEditor .toolbar .errorIcon {
   cursor: help;
+  font-family: sans-serif; /* Ensures the emoji is shown in color. */
   font-size: 13px;
   margin: 0 4px;
   position: relative;

--- a/src/components/example-list.vue
+++ b/src/components/example-list.vue
@@ -56,6 +56,13 @@ function uniqueId() {
   return 'example' + idCounter++;
 }
 
+const defaultExampleValue = () => ({
+  text: '',
+  startRule: '',
+  selectedGrammar: '',
+  shouldMatch: true,
+});
+
 // Exports
 // -------
 
@@ -90,9 +97,7 @@ export default {
     },
     selectedExampleOrEmpty() {
       const ex = this.getSelected();
-      return (
-        ex || {text: '', startRule: '', selectedGrammar: '', shouldMatch: true}
-      );
+      return ex || defaultExampleValue();
     },
   },
   watch: {
@@ -191,12 +196,7 @@ export default {
     // Every example added to the list must go through this function!
     addExample(optData) {
       const id = uniqueId();
-      this.$set(this.exampleValues, id, {
-        text: '',
-        startRule: '',
-        selectedGrammar: '',
-        shouldMatch: true,
-      });
+      this.$set(this.exampleValues, id, defaultExampleValue());
 
       this._watchExample(id, this.updateExampleStatus);
       this.selectedId = id;
@@ -275,10 +275,8 @@ export default {
         } else {
           examples = domUtil.$$('#sampleExamples pre').map((elem) => {
             return {
+              ...defaultExampleValue(),
               text: elem.textContent,
-              startRule: '',
-              selectedGrammar: '',
-              shouldMatch: true,
             };
           });
         }
@@ -288,18 +286,15 @@ export default {
 
       const newExampleValues = {};
 
-      const self = this;
-      examples.forEach(function (ex) {
-        const id = self.addExample();
+      for (const ex of examples) {
+        const id = this.addExample();
         // Some examples from localStorage may be missing keys, since the format has changed.
         // So we include default values here.
         newExampleValues[id] = {
-          selectedGrammar: '',
-          startRule: '',
-          shouldMatch: true,
+          ...defaultExampleValue(),
           ...ex,
         };
-      });
+      }
       this.exampleValues = newExampleValues;
 
       // Select the first example.

--- a/src/components/example-list.vue
+++ b/src/components/example-list.vue
@@ -56,12 +56,12 @@ function uniqueId() {
   return 'example' + idCounter++;
 }
 
-const defaultExampleValue = () => ({
+const EXAMPLE_DEFAULTS = {
   text: '',
   startRule: '',
   selectedGrammar: '',
   shouldMatch: true,
-});
+};
 
 // Exports
 // -------
@@ -97,7 +97,7 @@ export default {
     },
     selectedExampleOrEmpty() {
       const ex = this.getSelected();
-      return ex || defaultExampleValue();
+      return ex || {...EXAMPLE_DEFAULTS};
     },
   },
   watch: {
@@ -196,7 +196,7 @@ export default {
     // Every example added to the list must go through this function!
     addExample(optData) {
       const id = uniqueId();
-      this.$set(this.exampleValues, id, defaultExampleValue());
+      this.$set(this.exampleValues, id, {...EXAMPLE_DEFAULTS});
 
       this._watchExample(id, this.updateExampleStatus);
       this.selectedId = id;
@@ -275,7 +275,7 @@ export default {
         } else {
           examples = domUtil.$$('#sampleExamples pre').map((elem) => {
             return {
-              ...defaultExampleValue(),
+              ...EXAMPLE_DEFAULTS,
               text: elem.textContent,
             };
           });
@@ -291,7 +291,7 @@ export default {
         // Some examples from localStorage may be missing keys, since the format has changed.
         // So we include default values here.
         newExampleValues[id] = {
-          ...defaultExampleValue(),
+          ...EXAMPLE_DEFAULTS(),
           ...ex,
         };
       }

--- a/src/components/example-list.vue
+++ b/src/components/example-list.vue
@@ -291,10 +291,14 @@ export default {
       const self = this;
       examples.forEach(function (ex) {
         const id = self.addExample();
-        if (!Object.prototype.hasOwnProperty.call(ex, 'shouldMatch')) {
-          ex.shouldMatch = true;
-        }
-        newExampleValues[id] = ex;
+        // Some examples from localStorage may be missing keys, since the format has changed.
+        // So we include default values here.
+        newExampleValues[id] = {
+          selectedGrammar: '',
+          startRule: '',
+          shouldMatch: true,
+          ...ex,
+        };
       });
       this.exampleValues = newExampleValues;
 
@@ -335,7 +339,7 @@ export default {
         } else {
           status = {
             className: 'fail',
-            err: `No grammar named '${selectedGrammar}'`,
+            err: {message: `Unknown grammar '${selectedGrammar}'`},
           };
         }
         this.$set(this.exampleStatus, id, status);

--- a/src/components/example-list.vue
+++ b/src/components/example-list.vue
@@ -19,7 +19,7 @@
             @dblclick="handleDblClick"
           >
             <code>{{ ex.text }}</code>
-            <div class="startRule">{{ ex.startRule }}</div>
+            <div class="startRule">{{ getStartRuleLabel(ex) }}</div>
             <thumbs-up-button
               :showThumbsUp="ex.shouldMatch"
               @click.native="toggleShouldMatch(id)"
@@ -346,6 +346,10 @@ export default {
       } else {
         this.$delete(this.exampleStatus, id);
       }
+    },
+    getStartRuleLabel(example) {
+      const {selectedGrammar, startRule} = example;
+      return selectedGrammar ? `${selectedGrammar} ▸ ${startRule || '(default)'}` : startRule;
     },
 
     // Watch for changes to the example with the given id. When any of its data changes,

--- a/src/components/example-list.vue
+++ b/src/components/example-list.vue
@@ -349,7 +349,9 @@ export default {
     },
     getStartRuleLabel(example) {
       const {selectedGrammar, startRule} = example;
-      return selectedGrammar ? `${selectedGrammar} ▸ ${startRule || '(default)'}` : startRule;
+      return selectedGrammar
+        ? `${selectedGrammar} ▸ ${startRule || '(default)'}`
+        : startRule;
     },
 
     // Watch for changes to the example with the given id. When any of its data changes,

--- a/src/components/example-list.vue
+++ b/src/components/example-list.vue
@@ -352,9 +352,9 @@ export default {
       self.setGrammar(null);
     });
     ohmEditor.addListener(
-      'parse:grammar',
-      function (matchResult, grammar, err) {
-        self.setGrammar(grammar);
+      'parse:grammars',
+      function (matchResult, grammars, err) {
+        self.setGrammar(grammars ? Object.values(grammars)[0] : undefined);
       }
     );
     ohmEditor.addListener('change:inputEditor', function (source) {

--- a/src/components/thumbs-up-button.vue
+++ b/src/components/thumbs-up-button.vue
@@ -8,7 +8,9 @@
 <script>
 export default {
   name: 'thumbs-up-button',
-  props: ['showThumbsUp'],
+  props: {
+    showThumbsUp: {type: Boolean, required: true},
+  },
   computed: {
     title() {
       return 'Example should ' + (this.showThumbsUp ? 'match' : 'NOT match');

--- a/src/components/trace-element.vue
+++ b/src/components/trace-element.vue
@@ -180,7 +180,7 @@ export default {
       );
     },
     isLeaf() {
-      let leaf = isLeaf(ohmEditor.grammar, this.traceNode);
+      let leaf = isLeaf(ohmEditor.currentGrammar, this.traceNode);
       if (this.traceNode.isMemoized) {
         const memoKey = this.traceNode.expr.toMemoKey();
         const stack = this.currentLR[memoKey];
@@ -206,7 +206,7 @@ export default {
       // Collapse if the rule body has no source (e.g. anything from ProtoBuiltInRules).
       const pexpr = this.traceNode.expr;
       if (pexpr instanceof ohm.pexprs.Apply) {
-        const body = ohmEditor.grammar.rules[pexpr.ruleName].body;
+        const body = ohmEditor.currentGrammar.rules[pexpr.ruleName].body;
         if (!body.source) {
           return true;
         }
@@ -277,6 +277,7 @@ export default {
         lrObj[memoKey] = stack;
         stack.push(this.traceNode.pos);
         children.push({
+          id: getFreshNodeId(),
           traceNode: this.traceNode.terminatingLREntry,
           context: this.context,
           isInVBox: true,
@@ -430,7 +431,7 @@ export default {
       } else if (modifier === 'cmd') {
         // cmd/ctrl + click to open or close semantic editor
         ohmEditor.parseTree.emit('cmdOrCtrlClick:traceElement', this.$el);
-      } else if (!isLeaf(ohmEditor.grammar, this.traceNode)) {
+      } else if (!isLeaf(ohmEditor.currentGrammar, this.traceNode)) {
         this.toggleCollapsed();
       }
     },

--- a/src/editorErrors.js
+++ b/src/editorErrors.js
@@ -82,14 +82,13 @@ function createErrorEl(result, pos) {
 ohmEditor.addListener('change:grammarEditor', function (cm) {
   hideError('grammar', cm);
 });
-ohmEditor.addListener('change:inputEditor', function (cm) {
-  hideError('input', cm);
-});
 
-// Hide the input error when the grammar is about to be reparsed.
-ohmEditor.addListener('change:grammars', function (source) {
-  hideError('input', ohmEditor.ui.inputEditor);
-});
+const hideInputError = (_) => hideError('input', ohmEditor.ui.inputEditor);
+
+// Hide errors in the input in all cases where the input will be reparsed.
+ohmEditor.addListener('change:inputEditor', hideInputError);
+ohmEditor.addListener('change:grammars', hideInputError);
+ohmEditor.addListener('set:startRule', hideInputError);
 
 ohmEditor.addListener('parse:grammars', function (matchResult, grammars, err) {
   if (err) {

--- a/src/editorErrors.js
+++ b/src/editorErrors.js
@@ -91,7 +91,7 @@ ohmEditor.addListener('change:grammar', function (source) {
   hideError('input', ohmEditor.ui.inputEditor);
 });
 
-ohmEditor.addListener('parse:grammar', function (matchResult, grammar, err) {
+ohmEditor.addListener('parse:grammars', function (matchResult, grammars, err) {
   if (err) {
     const editor = ohmEditor.ui.grammarEditor;
     setError('grammar', editor, err.interval, err.shortMessage || err.message);

--- a/src/editorErrors.js
+++ b/src/editorErrors.js
@@ -87,7 +87,7 @@ ohmEditor.addListener('change:inputEditor', function (cm) {
 });
 
 // Hide the input error when the grammar is about to be reparsed.
-ohmEditor.addListener('change:grammar', function (source) {
+ohmEditor.addListener('change:grammars', function (source) {
   hideError('input', ohmEditor.ui.inputEditor);
 });
 

--- a/src/externalRules.js
+++ b/src/externalRules.js
@@ -149,8 +149,8 @@ LastLineWidget.prototype.clear = function () {
   this.lineHandle.off('delete', this.placeWidget);
 };
 
-LastLineWidget.prototype.update = function (cm, matchResult, grammar) {
-  if (grammar) {
+LastLineWidget.prototype.update = function (cm, matchResult) {
+  if (matchResult.succeeded()) {
     this._rules = getExternalRules(semantics(matchResult).referencedRules);
   } else {
     const lenientResult = ohmGrammar.match(cm.getValue(), 'tokens');
@@ -173,13 +173,10 @@ const grammarEditor = ohmEditor.ui.grammarEditor;
 
 // Singletons associated with the current grammar (ok since there's only one grammar editor).
 let widget;
-const grammarState = {
-  matchResult: null,
-  grammar: null,
-};
+let grammarMatchResult;
 
 function updateExternalRules() {
-  widget.update(grammarEditor, grammarState.matchResult, grammarState.grammar);
+  widget.update(grammarEditor, grammarMatchResult);
 }
 
 grammarEditor.on('swapDoc', function (cm) {
@@ -187,14 +184,13 @@ grammarEditor.on('swapDoc', function (cm) {
 });
 
 ohmEditor.addListener('parse:grammars', function (matchResult, grammars, err) {
-  grammarState.matchResult = matchResult;
-  grammarState.grammar = grammars ? Object.values(grammars)[0] : undefined;
+  grammarMatchResult = matchResult;
   updateExternalRules();
 });
 
 ohmEditor.addListener('change:option', function (name) {
   if (name === 'showSpaces') {
-    updateExternalRules(grammarState.grammarMatchResult, grammarState.grammar);
+    updateExternalRules();
   }
 });
 

--- a/src/externalRules.js
+++ b/src/externalRules.js
@@ -186,9 +186,9 @@ grammarEditor.on('swapDoc', function (cm) {
   widget = new LastLineWidget(cm);
 });
 
-ohmEditor.addListener('parse:grammar', function (matchResult, grammar, err) {
+ohmEditor.addListener('parse:grammars', function (matchResult, grammars, err) {
   grammarState.matchResult = matchResult;
-  grammarState.grammar = grammar;
+  grammarState.grammar = grammars ? Object.values(grammars)[0] : undefined;
   updateExternalRules();
 });
 

--- a/src/externalRules.js
+++ b/src/externalRules.js
@@ -195,9 +195,8 @@ ohmEditor.addListener('change:option', function (name) {
 });
 
 ohmEditor.addListener('peek:ruleDefinition', function (ruleName) {
-  if (
-    !Object.prototype.hasOwnProperty.call(ohmEditor.grammar.rules, ruleName)
-  ) {
+  const g = ohmEditor.grammars ? Object.values(ohmEditor.grammars)[0] : null;
+  if (!Object.prototype.hasOwnProperty.call(g.rules, ruleName)) {
     const elem = $('#externalRules-' + ruleName);
     if (elem) {
       elem.classList.add('active-definition');

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,6 @@ function refresh() {
     const {matchResult, grammars, err} = parseGrammars();
     ohmEditor.emit('parse:grammars', matchResult, grammars, err);
   }
-
   const {currentGrammar} = ohmEditor;
   if (currentGrammar) {
     const startRule = getValidStartRule(currentGrammar, ohmEditor.startRule);
@@ -189,7 +188,10 @@ ohmEditor.ui.grammarEditor.on('swapDoc', function (cm) {
   triggerRefresh(250);
 });
 
-ohmEditor.addListener('set:currentGrammar', (ruleName) => {
+ohmEditor.addListener('set:currentGrammar', (grammar) => {
+  triggerRefresh();
+});
+ohmEditor.addListener('set:startRule', (ruleName) => {
   triggerRefresh();
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,20 +28,13 @@ let grammarMatcher = ohm.ohmGrammar.matcher();
 // Helpers
 // -------
 
-function parseGrammar() {
-  const matchResult = grammarMatcher.match();
-
-  let grammar;
+function parseGrammars() {
   let err;
-
+  const grammars = {};
+  const matchResult = grammarMatcher.match();
   if (matchResult.succeeded()) {
-    const ns = {};
     try {
-      ohm._buildGrammar(matchResult, ns);
-      const firstProp = Object.keys(ns)[0];
-      if (firstProp) {
-        grammar = ns[firstProp];
-      }
+      ohm._buildGrammar(matchResult, grammars);
     } catch (ex) {
       err = ex;
     }
@@ -54,8 +47,8 @@ function parseGrammar() {
   }
   return {
     matchResult,
-    grammar,
-    error: err,
+    grammars,
+    err,
   };
 }
 
@@ -99,14 +92,9 @@ function refresh() {
     grammarChanged = false;
     ohmEditor.emit('change:grammar', grammarSource);
 
-    const result = parseGrammar();
-    ohmEditor.grammar = result.grammar;
-    ohmEditor.emit(
-      'parse:grammar',
-      result.matchResult,
-      result.grammar,
-      result.error
-    );
+    const {matchResult, grammars, err} = parseGrammars();
+    ohmEditor.grammar = grammars ? Object.values(grammars)[0] : undefined;
+    ohmEditor.emit('parse:grammars', matchResult, grammars, err);
   }
 
   if (ohmEditor.grammar) {
@@ -216,7 +204,7 @@ console.log(
     '  `.grammar` as the current grammar object (if the source is valid)',
     '  `.ui` containing the `inputEditor` and `grammarEditor`',
     '',
-    `Ohm version ${ohm.version}`
+    `Ohm version ${ohm.version}`,
   ].join('\n')
 );
 /* eslint-enable no-console */

--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,6 @@ const $ = domUtil.$;
 const $$ = domUtil.$$;
 
 let grammarMatcher = ohm.ohmGrammar.matcher();
-let currentGrammar;
-let currentStartRule;
 
 // Helpers
 // -------
@@ -56,9 +54,9 @@ function parseGrammars() {
 
 // Return the name of a valid start rule for grammar, or null if `optRuleName` is
 // not valid and the grammar has no default starting rule.
-function getValidStartRule(grammar, optRuleName) {
-  if (optRuleName && optRuleName in grammar.rules) {
-    return optRuleName;
+function getValidStartRule(grammar, ruleName = '') {
+  if (ruleName && ruleName in grammar.rules) {
+    return ruleName;
   }
   if (grammar.defaultStartRule) {
     return grammar.defaultStartRule;
@@ -94,14 +92,14 @@ function refresh() {
     ohmEditor.emit('change:grammars', grammarSource);
 
     const {matchResult, grammars, err} = parseGrammars();
-    ohmEditor.grammar = grammars ? Object.values(grammars)[0] : undefined;
     ohmEditor.emit('parse:grammars', matchResult, grammars, err);
   }
 
-  if (ohmEditor.grammar) {
-    const startRule = getValidStartRule(ohmEditor.grammar, ohmEditor.startRule);
+  const {currentGrammar} = ohmEditor;
+  if (currentGrammar) {
+    const startRule = getValidStartRule(currentGrammar, ohmEditor.startRule);
     if (startRule) {
-      const trace = ohmEditor.grammar.trace(inputSource, startRule);
+      const trace = currentGrammar.trace(inputSource, startRule);
 
       // When the input fails to parse, turn on "show failures" automatically.
       if (showFailuresImplicitly) {
@@ -189,6 +187,10 @@ ohmEditor.ui.grammarEditor.on('swapDoc', function (cm) {
   grammarChanged = true;
   ohmEditor.emit('change:grammarEditor', cm);
   triggerRefresh(250);
+});
+
+ohmEditor.addListener('set:currentGrammar', (ruleName) => {
+  triggerRefresh();
 });
 
 window.ohmEditor = ohmEditor;

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ const $ = domUtil.$;
 const $$ = domUtil.$$;
 
 let grammarMatcher = ohm.ohmGrammar.matcher();
+let currentGrammar;
+let currentStartRule;
 
 // Helpers
 // -------
@@ -70,7 +72,6 @@ function refresh() {
 
   const grammarSource = grammarEditor.getValue();
   const inputSource = inputEditor.getValue();
-
   ohmEditor.saveState(inputEditor, 'input');
 
   // Refresh the option values.
@@ -90,7 +91,7 @@ function refresh() {
 
   if (grammarChanged) {
     grammarChanged = false;
-    ohmEditor.emit('change:grammar', grammarSource);
+    ohmEditor.emit('change:grammars', grammarSource);
 
     const {matchResult, grammars, err} = parseGrammars();
     ohmEditor.grammar = grammars ? Object.values(grammars)[0] : undefined;

--- a/src/ohmEditor.js
+++ b/src/ohmEditor.js
@@ -21,8 +21,8 @@ ohmEditor.registerEvents({
   'change:grammar': ['grammarSource'],
   'change:input': ['inputSource'],
 
-  // Emitted after attempting to parse the grammar and the input, respectively.
-  'parse:grammar': ['matchResult', 'grammar', 'err'],
+  // Emitted after attempting to parse the grammar(s) and the input, respectively.
+  'parse:grammars': ['matchResult', 'grammars', 'err'],
   'parse:input': ['matchResult', 'trace'],
 
   // Emitted when the user indicates they want to preview contextual information about a

--- a/src/ohmEditor.js
+++ b/src/ohmEditor.js
@@ -13,12 +13,12 @@ ohmEditor.registerEvents({
   'init:grammarEditor': ['codeMirror'],
 
   // Emitted as soon as the user has made a change in the respective editor. Any listeners which
-  // may be long running should use 'change:input' or 'change:grammar' instead.
+  // may be long running should use 'change:input' or 'change:grammars' instead.
   'change:inputEditor': ['codeMirror'],
   'change:grammarEditor': ['codeMirror'],
 
   // Emitted after a short delay when one or more editor change events have occurred.
-  'change:grammar': ['grammarSource'],
+  'change:grammars': ['grammarSource'],
   'change:input': ['inputSource'],
 
   // Emitted after attempting to parse the grammar(s) and the input, respectively.
@@ -45,7 +45,6 @@ ohmEditor.registerEvents({
 });
 
 ohmEditor.grammar = null;
-ohmEditor.startRule = null;
 ohmEditor.options = {};
 
 ohmEditor.semantics = new CheckedEmitter();

--- a/src/ohmEditor.js
+++ b/src/ohmEditor.js
@@ -28,6 +28,7 @@ ohmEditor.registerEvents({
   // The "current" grammar is determined by (a) the contents of the grammar editor, and
   // (b) the currently-selected example. This is emitted if either one changes.
   'set:currentGrammar': ['grammar'],
+  'set:startRule': ['startRule'],
 
   // Emitted when the user indicates they want to preview contextual information about a
   // Failure, e.g. when hovering over the failure message.
@@ -111,6 +112,7 @@ function updateCurrentGrammarAndStartRule() {
 
   if (example) {
     ohmEditor.startRule = example.startRule;
+    ohmEditor.emit('set:startRule', ohmEditor.startRule);
   }
 }
 

--- a/src/parseTree.js
+++ b/src/parseTree.js
@@ -33,10 +33,9 @@ parseTree.vue = new Vue({
     ohmEditor.addListener('change:grammarEditor', this.onEdit);
 
     // Refresh the parse tree after attempting to parse the input.
-    const self = this;
     ohmEditor.addListener('parse:input', (matchResult, trace) => {
-      self.parsing = false;
-      self.trace = Object.freeze(trace);
+      this.parsing = false;
+      this.trace = Object.freeze(trace);
     });
   },
 });

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -321,7 +321,7 @@ function doSaveAs() {
       document.title = 'Ohm';
     }
 
-    ohmEditor.once('change:grammar', function (_) {
+    ohmEditor.once('change:grammars', function (_) {
       saveButton.disabled = true;
     });
     if (examples) {
@@ -410,7 +410,7 @@ function doSaveAs() {
     },
   });
 
-  ohmEditor.addListener('change:grammar', function (source) {
+  ohmEditor.addListener('change:grammars', function (source) {
     const grammar = grammarList.options[grammarList.selectedIndex].value;
     if (grammar === '') {
       // local storage

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -224,7 +224,8 @@ function save() {
 
   const description = option.label;
   const grammarName =
-    (ohmEditor.grammar && ohmEditor.grammar.name) || 'grammar';
+    (ohmEditor.defaultGrammar() && ohmEditor.defaultGrammar().name) ||
+    'grammar';
   const grammarText = ohmEditor.ui.grammarEditor.getValue();
   const examples = ohmEditor.examples.getExamples();
 
@@ -292,7 +293,8 @@ function doSaveAs() {
     const description = $('#newGrammarName').value;
     $('#newGrammarName').value = '';
     const grammarName =
-      (ohmEditor.grammar && ohmEditor.grammar.name) || 'grammar';
+      (ohmEditor.defaultGrammar() && ohmEditor.defaultGrammar().name) ||
+      'grammar';
     const grammarText = ohmEditor.ui.grammarEditor.getValue();
     const examples = ohmEditor.examples.getExamples();
 

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -327,7 +327,7 @@ function doSaveAs() {
       saveButton.disabled = true;
     });
     if (examples) {
-      ohmEditor.once('parse:grammar', function (matchResult, grammar, err) {
+      ohmEditor.once('parse:grammars', function (matchResult, grammars, err) {
         ohmEditor.examples.restoreExamples(examples);
       });
     }

--- a/src/ruleHyperlinks.js
+++ b/src/ruleHyperlinks.js
@@ -124,12 +124,12 @@ function registerListeners(editor) {
   });
 }
 
-ohmEditor.addListener('parse:grammar', function (matchResult, g, err) {
+ohmEditor.addListener('parse:grammars', function (matchResult, grammars, err) {
   if (!grammarEditor) {
     grammarEditor = ohmEditor.ui.grammarEditor;
     registerListeners(grammarEditor);
   }
-  grammar = g;
+  grammar = grammars ? Object.values(grammars)[0] : undefined;
   grammarMemoTable = matchResult.succeeded()
     ? matchResult.matcher.memoTable
     : null;

--- a/test/test-example-list.js
+++ b/test/test-example-list.js
@@ -46,7 +46,7 @@ const ExampleList =
 // -------
 
 async function simulateGrammarEdit(source) {
-  await ohmEditor.emit('change:grammar', source);
+  await ohmEditor.emit('change:grammars', source);
   await Vue.nextTick();
 
   await ohmEditor.emit('parse:grammars', null, ohm.grammars(source), null);
@@ -193,7 +193,7 @@ test('pass/fail status', async () => {
   await Vue.nextTick();
   expect(vm.exampleStatus[id2].className).toBe('pass');
 
-  ohmEditor.emit('change:grammar', '');
+  ohmEditor.emit('change:grammars', '');
 
   await Vue.nextTick();
   for (const k of Object.keys(vm.exampleStatus)) {

--- a/test/test-example-list.js
+++ b/test/test-example-list.js
@@ -259,11 +259,6 @@ test('start rule dropdown', async () => {
 
   // ...but the unselected options should be updated.
   expect(getDropdownOptionValues(dropdown)).toEqual(['G.', 'G2.', 'G2.start']);
-
-  /*
-    Other problems:
-    - examples in the list should show "G > AddExp" rather than just "AddExp"
-   */
 });
 
 test('start rule errors', async () => {

--- a/test/test-example-list.js
+++ b/test/test-example-list.js
@@ -49,7 +49,7 @@ async function simulateGrammarEdit(source) {
   await ohmEditor.emit('change:grammar', source);
   await Vue.nextTick();
 
-  await ohmEditor.emit('parse:grammar', null, ohm.grammar(source), null);
+  await ohmEditor.emit('parse:grammars', null, ohm.grammars(source), null);
   await flushQueue();
 }
 

--- a/test/test-example-list.js
+++ b/test/test-example-list.js
@@ -263,7 +263,6 @@ test('start rule dropdown', async () => {
   /*
     Other problems:
     - examples in the list should show "G > AddExp" rather than just "AddExp"
-    - text in editor should be reparsed (it's not)
    */
 });
 

--- a/test/test-example-list.js
+++ b/test/test-example-list.js
@@ -222,9 +222,9 @@ test('start rule text', async () => {
   await Vue.nextTick();
   expect(findEl(vm, '.startRule').textContent).toBe('noSuchRule');
 
-  vm.setExample(id, '', '', 'start');
+  vm.setExample(id, '', 'MyGrammar', 'start');
   await Vue.nextTick();
-  expect(findEl(vm, '.startRule').textContent).toBe('start');
+  expect(findEl(vm, '.startRule').textContent).toBe('MyGrammar ▸ start');
 });
 
 test('start rule dropdown', async () => {


### PR DESCRIPTION
- Fixes #25: when picking a start rule, you can pick from any of the grammars.
- For existing examples (e.g. from localStorage), it defaults to the last grammar that is defined (more useful that defaulting to the first.
-  Also fixes #45
- Still TODO:
   * [ ] Fix 'peek:ruleDefinition' to look at the correct grammar
   * [ ] Fix rule hyperlinks