### PR TITLE
fix(multi-grammar): Fix 'peek:ruleDefinition' to use the right grammar

### DIFF
--- a/src/cmUtil.js
+++ b/src/cmUtil.js
@@ -42,6 +42,11 @@ function markBlock(cm, startLine, endLine, className) {
 // -------
 
 module.exports = {
+  containsInterval(cm, interval) {
+    const startPos = cm.posFromIndex(interval.startIdx);
+    const endPos = cm.posFromIndex(interval.endIdx);
+    return cm.getRange(startPos, endPos) === interval.contents;
+  },
   markInterval(cm, interval, className, canHighlightBlocks) {
     const startPos = cm.posFromIndex(interval.startIdx);
     const endPos = cm.posFromIndex(interval.endIdx);

--- a/src/components/example-list.vue
+++ b/src/components/example-list.vue
@@ -291,7 +291,7 @@ export default {
         // Some examples from localStorage may be missing keys, since the format has changed.
         // So we include default values here.
         newExampleValues[id] = {
-          ...EXAMPLE_DEFAULTS(),
+          ...EXAMPLE_DEFAULTS,
           ...ex,
         };
       }

--- a/src/components/parse-tree.vue
+++ b/src/components/parse-tree.vue
@@ -109,21 +109,20 @@ export default {
   mounted() {
     window.addEventListener('resize', this.$refs.expandedInput.update);
 
-    ohmEditor.addListener('peek:ruleDefinition', function (ruleName) {
-      if (
-        Object.prototype.hasOwnProperty.call(ohmEditor.grammar.rules, ruleName)
-      ) {
-        const defInterval = ohmEditor.grammar.rules[ruleName].source;
-        if (defInterval) {
-          const grammarEditor = ohmEditor.ui.grammarEditor;
-          defMark = cmUtil.markInterval(
-            grammarEditor,
-            defInterval,
-            'active-definition',
-            true
-          );
-          cmUtil.scrollToInterval(grammarEditor, defInterval);
-        }
+    ohmEditor.addListener('peek:ruleDefinition', function (grammar, ruleName) {
+      const cm = ohmEditor.ui.grammarEditor;
+      const defInterval = grammar.rules[ruleName].source;
+
+      // If the text in the grammar editor doesn't match the interval contents, then it's
+      // an external rule, and this handler should ignore it.
+      if (defInterval && cmUtil.containsInterval(cm, defInterval)) {
+        defMark = cmUtil.markInterval(
+          cm,
+          defInterval,
+          'active-definition',
+          true
+        );
+        cmUtil.scrollToInterval(cm, defInterval);
       }
     });
     ohmEditor.addListener('unpeek:ruleDefinition', clearMarks);

--- a/src/components/trace-element.vue
+++ b/src/components/trace-element.vue
@@ -417,7 +417,11 @@ export default {
       }
       const ruleName = pexpr.ruleName;
       if (ruleName) {
-        ohmEditor.emit('peek:ruleDefinition', ruleName);
+        ohmEditor.emit(
+          'peek:ruleDefinition',
+          ohmEditor.currentGrammar,
+          ruleName
+        );
       }
       this.eventHandlers.hover();
     },

--- a/src/externalRules.js
+++ b/src/externalRules.js
@@ -3,9 +3,10 @@
 
 'use strict';
 
+const cmUtil = require('./cmUtil');
 const domUtil = require('./domUtil');
-const isPrimitiveRule = require('./traceUtil').isPrimitiveRule;
 const ohmEditor = require('./ohmEditor');
+const isPrimitiveRule = require('./traceUtil').isPrimitiveRule;
 
 const $ = domUtil.$;
 const $$ = domUtil.$$;
@@ -194,9 +195,10 @@ ohmEditor.addListener('change:option', function (name) {
   }
 });
 
-ohmEditor.addListener('peek:ruleDefinition', function (ruleName) {
-  const g = ohmEditor.grammars ? Object.values(ohmEditor.grammars)[0] : null;
-  if (!Object.prototype.hasOwnProperty.call(g.rules, ruleName)) {
+ohmEditor.addListener('peek:ruleDefinition', function (grammar, ruleName) {
+  const cm = ohmEditor.ui.grammarEditor;
+  const defInterval = grammar.rules[ruleName].source;
+  if (defInterval && !cmUtil.containsInterval(cm, defInterval)) {
     const elem = $('#externalRules-' + ruleName);
     if (elem) {
       elem.classList.add('active-definition');

--- a/src/ohmEditor.js
+++ b/src/ohmEditor.js
@@ -42,7 +42,7 @@ ohmEditor.registerEvents({
 
   // Emitted when the user indicates they want to preview a rule definition, e.g. when
   // hovering over a node in the visualizer.
-  'peek:ruleDefinition': ['ruleName'],
+  'peek:ruleDefinition': ['grammar', 'ruleName'],
   'unpeek:ruleDefinition': [], // Ends the preview.
 
   // Emitted when the user checks or unchecks one of the option checkboxes.


### PR DESCRIPTION
Address one of the remaining issues in #25.